### PR TITLE
Add coauthor

### DIFF
--- a/pkg/commands/git_commands/commit.go
+++ b/pkg/commands/git_commands/commit.go
@@ -38,6 +38,24 @@ func (self *CommitCommands) SetAuthor(value string) error {
 	return self.cmd.New(cmdArgs).Run()
 }
 
+// Add a commit's coauthor using Github/Gitlab Co-authored-by metadata. Value is expected to be of the form 'Name <Email>'
+func (self *CommitCommands) AddCoAuthor(sha string, value string) error {
+	message, err := self.GetCommitMessage(sha)
+	if err != nil {
+		return err
+	}
+
+	message = message + fmt.Sprintf("\nCo-authored-by: %s", value)
+
+	args := []string{"-m", message}
+	cmdArgs := NewGitCmd("commit").
+		Arg("--allow-empty", "--amend", "--only").
+		Arg(args...).
+		ToArgv()
+
+	return self.cmd.New(cmdArgs).Run()
+}
+
 // ResetToCommit reset to commit
 func (self *CommitCommands) ResetToCommit(sha string, strength string, envVars []string) error {
 	cmdArgs := NewGitCmd("reset").Arg("--"+strength, sha).ToArgv()

--- a/pkg/commands/git_commands/commit.go
+++ b/pkg/commands/git_commands/commit.go
@@ -47,10 +47,8 @@ func (self *CommitCommands) AddCoAuthor(sha string, value string) error {
 
 	message = message + fmt.Sprintf("\nCo-authored-by: %s", value)
 
-	args := []string{"-m", message}
 	cmdArgs := NewGitCmd("commit").
-		Arg("--allow-empty", "--amend", "--only").
-		Arg(args...).
+		Arg("--allow-empty", "--amend", "--only", "-m", message).
 		ToArgv()
 
 	return self.cmd.New(cmdArgs).Run()

--- a/pkg/commands/git_commands/rebase.go
+++ b/pkg/commands/git_commands/rebase.go
@@ -79,6 +79,12 @@ func (self *RebaseCommands) SetCommitAuthor(commits []*models.Commit, index int,
 	})
 }
 
+func (self *RebaseCommands) AddCommitCoAuthor(commits []*models.Commit, index int, value string) error {
+	return self.GenericAmend(commits, index, func() error {
+		return self.commit.AddCoAuthor(commits[index].Sha, value)
+	})
+}
+
 func (self *RebaseCommands) GenericAmend(commits []*models.Commit, index int, f func() error) error {
 	if models.IsHeadCommit(commits, index) {
 		// we've selected the top commit so no rebase is required

--- a/pkg/gui/controllers/local_commits_controller.go
+++ b/pkg/gui/controllers/local_commits_controller.go
@@ -625,7 +625,7 @@ func (self *LocalCommitsController) amendAttribute(commit *models.Commit) error 
 				Label:   self.c.Tr.AddCoAuthor,
 				OnPress: self.addCoAuthor,
 				Key:     'c',
-				Tooltip: "Add co-author using the Github/Gitlab metadata Co-authored-by",
+				Tooltip: self.c.Tr.AddCoAuthorTooltip,
 			},
 		},
 	})

--- a/pkg/gui/controllers/local_commits_controller.go
+++ b/pkg/gui/controllers/local_commits_controller.go
@@ -621,6 +621,12 @@ func (self *LocalCommitsController) amendAttribute(commit *models.Commit) error 
 				Key:     'A',
 				Tooltip: "Set the author based on a prompt",
 			},
+			{
+				Label:   self.c.Tr.AddCoAuthor,
+				OnPress: self.addCoAuthor,
+				Key:     'c',
+				Tooltip: "Add co-author using the Github/Gitlab metadata Co-authored-by",
+			},
 		},
 	})
 }
@@ -647,6 +653,22 @@ func (self *LocalCommitsController) setAuthor() error {
 					return self.c.Error(err)
 				}
 
+				return self.c.Refresh(types.RefreshOptions{Mode: types.ASYNC})
+			})
+		},
+	})
+}
+
+func (self *LocalCommitsController) addCoAuthor() error {
+	return self.c.Prompt(types.PromptOpts{
+		Title:               self.c.Tr.AddCoAuthorPromptTitle,
+		FindSuggestionsFunc: self.c.Helpers().Suggestions.GetAuthorsSuggestionsFunc(),
+		HandleConfirm: func(value string) error {
+			return self.c.WithWaitingStatus(self.c.Tr.AmendingStatus, func(gocui.Task) error {
+				self.c.LogAction(self.c.Tr.Actions.AddCommitCoAuthor)
+				if err := self.c.Git().Rebase.AddCommitCoAuthor(self.c.Model().Commits, self.context().GetSelectedLineIdx(), value); err != nil {
+					return self.c.Error(err)
+				}
 				return self.c.Refresh(types.RefreshOptions{Mode: types.ASYNC})
 			})
 		},

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -107,6 +107,7 @@ type TranslationSet struct {
 	SetResetCommitAuthor                string
 	SetAuthorPromptTitle                string
 	AddCoAuthorPromptTitle              string
+	AddCoAuthorTooltip                  string
 	SureResetCommitAuthor               string
 	RenameCommitEditor                  string
 	NoCommitsThisBranch                 string
@@ -897,6 +898,7 @@ func EnglishTranslationSet() TranslationSet {
 		SetResetCommitAuthor:                "Set/Reset commit author",
 		SetAuthorPromptTitle:                "Set author (must look like 'Name <Email>')",
 		AddCoAuthorPromptTitle:              "Add co-author (must look like 'Name <Email>')",
+		AddCoAuthorTooltip:                  "Add co-author using the Github/Gitlab metadata Co-authored-by",
 		SureResetCommitAuthor:               "The author field of this commit will be updated to match the configured user. This also renews the author timestamp. Continue?",
 		RenameCommitEditor:                  "Reword commit with editor",
 		Error:                               "Error",

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -103,8 +103,10 @@ type TranslationSet struct {
 	AmendToCommit                       string
 	ResetAuthor                         string
 	SetAuthor                           string
+	AddCoAuthor                         string
 	SetResetCommitAuthor                string
 	SetAuthorPromptTitle                string
+	AddCoAuthorPromptTitle              string
 	SureResetCommitAuthor               string
 	RenameCommitEditor                  string
 	NoCommitsThisBranch                 string
@@ -674,6 +676,7 @@ type Actions struct {
 	AmendCommit                       string
 	ResetCommitAuthor                 string
 	SetCommitAuthor                   string
+	AddCommitCoAuthor                 string
 	RevertCommit                      string
 	CreateFixupCommit                 string
 	SquashAllAboveFixupCommits        string
@@ -890,8 +893,10 @@ func EnglishTranslationSet() TranslationSet {
 		AmendToCommit:                       "Amend commit with staged changes",
 		ResetAuthor:                         "Reset author",
 		SetAuthor:                           "Set author",
+		AddCoAuthor:                         "Add co-author",
 		SetResetCommitAuthor:                "Set/Reset commit author",
 		SetAuthorPromptTitle:                "Set author (must look like 'Name <Email>')",
+		AddCoAuthorPromptTitle:              "Add co-author (must look like 'Name <Email>')",
 		SureResetCommitAuthor:               "The author field of this commit will be updated to match the configured user. This also renews the author timestamp. Continue?",
 		RenameCommitEditor:                  "Reword commit with editor",
 		Error:                               "Error",

--- a/pkg/integration/tests/commit/add_co_author.go
+++ b/pkg/integration/tests/commit/add_co_author.go
@@ -11,48 +11,14 @@ var AddCoAuthor = NewIntegrationTest(NewIntegrationTestArgs{
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {
-		shell.NewBranch("original")
-
-		shell.SetConfig("user.email", "Bill@example.com")
-		shell.SetConfig("user.name", "Bill Smith")
-
-		shell.EmptyCommit("one")
-
-		shell.NewBranch("other")
-
-		shell.SetConfig("user.email", "John@example.com")
-		shell.SetConfig("user.name", "John Smith")
-
-		shell.EmptyCommit("two")
-
-		shell.Checkout("original")
+		shell.EmptyCommit("initial commit")
 	},
 	Run: func(t *TestDriver, keys config.KeybindingConfig) {
 		t.Views().Commits().
 			Focus().
 			Lines(
-				Contains("BS").Contains("one").IsSelected(),
-			)
-
-		t.Views().Branches().
-			Focus().
-			Lines(
-				Contains("original").IsSelected(),
-				Contains("other"),
+				Contains("initial commit").IsSelected(),
 			).
-			NavigateToLine(Contains("other")).
-			PressEnter()
-
-		// ensuring we get these commit authors as suggestions
-		t.Views().SubCommits().
-			IsFocused().
-			Lines(
-				Contains("JS").Contains("two").IsSelected(),
-				Contains("BS").Contains("one"),
-			)
-
-		t.Views().Commits().
-			Focus().
 			Press(keys.Commits.ResetCommitAuthor).
 			Tap(func() {
 				t.ExpectPopup().Menu().
@@ -62,14 +28,13 @@ var AddCoAuthor = NewIntegrationTest(NewIntegrationTestArgs{
 
 				t.ExpectPopup().Prompt().
 					Title(Contains("Add co-author")).
-					SuggestionLines(
-						Contains("Bill Smith"),
-						Contains("John Smith"),
-					).
-					ConfirmSuggestion(Contains("John Smith"))
+					Type("John Smith <jsmith@gmail.com>").
+					Confirm()
 			})
+
 		t.Views().Main().ContainsLines(
-			Contains("Co-authored-by"),
+			Contains("initial commit"),
+			Contains("Co-authored-by: John Smith <jsmith@gmail.com>"),
 		)
 	},
 })

--- a/pkg/integration/tests/commit/add_co_author.go
+++ b/pkg/integration/tests/commit/add_co_author.go
@@ -1,0 +1,75 @@
+package commit
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var AddCoAuthor = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Add co-author on a commit",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig:  func(config *config.AppConfig) {},
+	SetupRepo: func(shell *Shell) {
+		shell.NewBranch("original")
+
+		shell.SetConfig("user.email", "Bill@example.com")
+		shell.SetConfig("user.name", "Bill Smith")
+
+		shell.EmptyCommit("one")
+
+		shell.NewBranch("other")
+
+		shell.SetConfig("user.email", "John@example.com")
+		shell.SetConfig("user.name", "John Smith")
+
+		shell.EmptyCommit("two")
+
+		shell.Checkout("original")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Commits().
+			Focus().
+			Lines(
+				Contains("BS").Contains("one").IsSelected(),
+			)
+
+		t.Views().Branches().
+			Focus().
+			Lines(
+				Contains("original").IsSelected(),
+				Contains("other"),
+			).
+			NavigateToLine(Contains("other")).
+			PressEnter()
+
+		// ensuring we get these commit authors as suggestions
+		t.Views().SubCommits().
+			IsFocused().
+			Lines(
+				Contains("JS").Contains("two").IsSelected(),
+				Contains("BS").Contains("one"),
+			)
+
+		t.Views().Commits().
+			Focus().
+			Press(keys.Commits.ResetCommitAuthor).
+			Tap(func() {
+				t.ExpectPopup().Menu().
+					Title(Equals("Amend commit attribute")).
+					Select(Contains("Add co-author")).
+					Confirm()
+
+				t.ExpectPopup().Prompt().
+					Title(Contains("Add co-author")).
+					SuggestionLines(
+						Contains("Bill Smith"),
+						Contains("John Smith"),
+					).
+					ConfirmSuggestion(Contains("John Smith"))
+			})
+		t.Views().Main().ContainsLines(
+			Contains("Co-authored-by"),
+		)
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -55,6 +55,7 @@ var tests = []*components.IntegrationTest{
 	branch.Suggestions,
 	cherry_pick.CherryPick,
 	cherry_pick.CherryPickConflicts,
+	commit.AddCoAuthor,
 	commit.Amend,
 	commit.Commit,
 	commit.CommitMultiline,


### PR DESCRIPTION
Add addCoAuthor command for commits

- Implement the `addCoAuthor` command to add co-authors to commits.
- Utilize suggestions helpers to populate author names from the suggestions list.
- Added command to gui at `LocalCommitsController`.

This commit introduces the `addCoAuthor` command, which allows users to easily add co-authors to their commits. The co-author names are populated from the suggestions list, minimizing the chances of user input errors. The co-authors are added using the Co-authored-by metadata format recognized by GitHub and GitLab.